### PR TITLE
Make balance equatable

### DIFF
--- a/KinEcosystem.podspec
+++ b/KinEcosystem.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KinEcosystem'
-  s.version          = '0.4.1'
+  s.version          = '0.4.2'
   s.summary          = 'Kin Ecosystem mobile sdk for iOS'
   s.description      = <<-DESC
 Kin ecosystem mobile sdk for iOS

--- a/KinEcosystem/Blockchain/Balance.swift
+++ b/KinEcosystem/Blockchain/Balance.swift
@@ -9,4 +9,8 @@ import Foundation
 
 public struct Balance: Codable, Equatable {
     public var amount: Decimal
+
+    public static func ==(lhs: ProductTransactionParameters, rhs: ProductTransactionParameters) -> Bool {
+        return lhs.amount == rhs.balance
+    }
 }

--- a/KinEcosystem/Core/Environment.swift
+++ b/KinEcosystem/Core/Environment.swift
@@ -14,6 +14,15 @@ public struct EnvironmentProperties: Codable, Equatable {
     let marketplaceURL: String
     let webURL: String
     let BIURL: String
+
+    public static func ==(lhs: EnvironmentProperties, rhs: EnvironmentProperties) -> Bool {
+        return lhs.blockchainURL == rhs.blockchainURL &&
+            lhs.blockchainPassphrase == rhs.blockchainPassphrase &&
+            lhs.kinIssuer == rhs.kinIssuer &&
+            lhs.marketplaceURL == rhs.marketplaceURL &&
+            lhs.webURL == rhs.webURL &&
+            lhs.BIURL == rhs.BIURL
+    }
 }
 
 public enum Environment {


### PR DESCRIPTION
I can't get it to build locally for some reason so I can't check if this compiles.

Anyway, on Swift 4.0, things are not implicitly `Equatable`, so this is required before being able to include the pod.