### PR TITLE
Upgrad the SDK version to the min CocoaPods version

### DIFF
--- a/KinEcosystem/KinEcosystem.xcodeproj/project.pbxproj
+++ b/KinEcosystem/KinEcosystem.xcodeproj/project.pbxproj
@@ -1631,7 +1631,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = KinEcosystem/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Kik.KinEcosystem;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1655,7 +1655,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = KinEcosystem/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Kik.KinEcosystem;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/KinEcosystem/KinEcosystem/API/EcosystemNet.swift
+++ b/KinEcosystem/KinEcosystem/API/EcosystemNet.swift
@@ -16,7 +16,6 @@ struct EcosystemConfiguration {
     var baseURL: URL
 }
 
-@available(iOS 9.0, *)
 class EcosystemNet {
     
     var client: RestClient!

--- a/KinEcosystem/KinEcosystem/API/RestClient.swift
+++ b/KinEcosystem/KinEcosystem/API/RestClient.swift
@@ -19,7 +19,6 @@ enum EcosystemNetError: Error {
     case unknown
 }
 
-@available(iOS 9.0, *)
 class RestClient {
     
     fileprivate(set) var config: EcosystemConfiguration

--- a/KinEcosystem/KinEcosystem/BackupModule/BackupRestore.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/BackupRestore.swift
@@ -42,7 +42,6 @@ private struct BRInstance {
     let completion: BRCompletionHandler
 }
 
-@available(iOS 9.0, *)
 public class BRManager: NSObject {
     private let storeProvider: KeystoreProvider
     private var presentor: UIViewController?
@@ -131,7 +130,6 @@ public class BRManager: NSObject {
 
 // MARK: - Navigation
 
-@available(iOS 9.0, *)
 extension BRManager {
     private var navigationController: UINavigationController? {
         return brInstance?.flowController.navigationController
@@ -164,7 +162,6 @@ extension BRManager {
 
 // MARK: - Flow
 
-@available(iOS 9.0, *)
 extension BRManager: FlowControllerDelegate {
     func flowControllerDidComplete(_ controller: FlowController) {
         guard let brInstance = brInstance else {
@@ -205,7 +202,6 @@ extension BRManager: FlowControllerDelegate {
 
 // MARK: - Navigation Bar Appearance
 
-@available(iOS 9.0, *)
 extension BRManager {
     private func removeNavigationBarBackground(_ navigationBar: UINavigationBar, shouldSave: Bool = false) {
         if shouldSave {

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/BackupCompletedViewController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/BackupCompletedViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 class BackupCompletedViewController: ExplanationTemplateViewController {
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/BackupFlowController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/BackupFlowController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 class BackupFlowController: FlowController {
     private lazy var _entryViewController: UIViewController = {
         let viewController = BackupIntroViewController()
@@ -22,7 +21,6 @@ class BackupFlowController: FlowController {
     }
 }
 
-@available(iOS 9.0, *)
 extension BackupFlowController: LifeCycleProtocol {
     func viewController(_ viewController: UIViewController, willAppear animated: Bool) {
         syncNavigationBarColor(with: viewController)
@@ -35,7 +33,6 @@ extension BackupFlowController: LifeCycleProtocol {
 
 // MARK: - Navigation
 
-@available(iOS 9.0, *)
 extension BackupFlowController {
     @objc private func pushPasswordViewController() {
         Kin.track { try BackupStartButtonTapped() }
@@ -69,7 +66,6 @@ extension BackupFlowController {
 
 // MARK: - Password
 
-@available(iOS 9.0, *)
 extension BackupFlowController: PasswordEntryDelegate {
     func validatePasswordConformance(_ password: String) -> Bool {
         return keystoreProvider.validatePassword(password)
@@ -89,11 +85,8 @@ extension BackupFlowController: PasswordEntryDelegate {
     }
 }
 
-@available(iOS 9.0, *)
 extension BackupFlowController: QRViewControllerDelegate {
     func QRViewControllerDidComplete() {
         pushCompletedViewController()
     }
-    
-    
 }

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/BackupIntroViewController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/BackupIntroViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 class BackupIntroViewController: ExplanationTemplateViewController {
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/ExplanationTemplateViewController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/ExplanationTemplateViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 class ExplanationTemplateViewController: BRViewController {
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/PasswordEntryField.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/PasswordEntryField.swift
@@ -13,7 +13,6 @@ public enum PasswordEntryFieldState {
     case invalid
 }
 
-@available(iOS 9.0, *)
 class PasswordEntryField: UITextField {
     
     public var entryState = PasswordEntryFieldState.idle {

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/PasswordEntryViewController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/PasswordEntryViewController.swift
@@ -8,15 +8,12 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 protocol PasswordEntryDelegate: NSObjectProtocol {
     func validatePasswordConformance(_ password: String) -> Bool
     func passwordEntryViewControllerDidComplete(_ viewController: PasswordEntryViewController)
 }
 
-@available(iOS 9.0, *)
 class PasswordEntryViewController: BRViewController {
-    
     @IBOutlet weak var passwordInfo: UILabel!
     @IBOutlet weak var passwordInput1: PasswordEntryField!
     @IBOutlet weak var passwordInput2: PasswordEntryField!

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/QRViewController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/QRViewController.swift
@@ -13,7 +13,6 @@ protocol QRViewControllerDelegate: NSObjectProtocol {
     func QRViewControllerDidComplete()
 }
 
-@available(iOS 9.0, *)
 class QRViewController: BRViewController {
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var qrImageView: UIImageView!
@@ -114,7 +113,6 @@ class QRViewController: BRViewController {
 
 // MARK: - Email
 
-@available(iOS 9.0, *)
 extension QRViewController {
     private enum EmailError: Error {
         case noClient
@@ -173,7 +171,6 @@ extension QRViewController {
     }
 }
 
-@available(iOS 9.0, *)
 extension QRViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         dismiss(animated: true) { [weak self] in

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/RestoreFlowController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/RestoreFlowController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 class RestoreFlowController: FlowController {
     private var qrPickerController: QRPickerController?
     
@@ -24,7 +23,6 @@ class RestoreFlowController: FlowController {
     }
 }
 
-@available(iOS 9.0, *)
 extension RestoreFlowController: LifeCycleProtocol {
     func viewController(_ viewController: UIViewController, willAppear animated: Bool) {
         syncNavigationBarColor(with: viewController)
@@ -37,7 +35,6 @@ extension RestoreFlowController: LifeCycleProtocol {
 
 // MARK: - Navigation
 
-@available(iOS 9.0, *)
 extension RestoreFlowController {
     private func presentQRPickerViewController() {
         guard QRPickerController.canOpenImagePicker else {
@@ -64,14 +61,12 @@ extension RestoreFlowController {
 
 // MARK: - Flow
 
-@available(iOS 9.0, *)
 extension RestoreFlowController: RestoreIntroViewControllerDelegate {
     func restoreIntroViewControllerDidComplete(_ viewController: RestoreIntroViewController) {
         presentQRPickerViewController()
     }
 }
 
-@available(iOS 9.0, *)
 extension RestoreFlowController: QRPickerControllerDelegate {
     func qrPickerControllerDidComplete(_ controller: QRPickerController, with qrString: String?) {
         controller.imagePickerController.presentingViewController?.dismiss(animated: true)
@@ -82,7 +77,6 @@ extension RestoreFlowController: QRPickerControllerDelegate {
     }
 }
 
-@available(iOS 9.0, *)
 extension RestoreFlowController: RestoreViewControllerDelegate {
     func restoreViewControllerDidImport(_ viewController: RestoreViewController, completion:@escaping (RestoreViewController.ImportResult) -> ()) {
         guard let password = viewController.password else {

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/RestoreIntroViewController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/RestoreIntroViewController.swift
@@ -8,12 +8,10 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 protocol RestoreIntroViewControllerDelegate: NSObjectProtocol {
     func restoreIntroViewControllerDidComplete(_ viewController: RestoreIntroViewController)
 }
 
-@available(iOS 9.0, *)
 class RestoreIntroViewController: ExplanationTemplateViewController {
     weak var delegate: RestoreIntroViewControllerDelegate?
     private var canContinue = false

--- a/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/RestoreViewController.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/View/notNibs/RestoreViewController.swift
@@ -8,13 +8,11 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 protocol RestoreViewControllerDelegate: NSObjectProtocol {
     func restoreViewControllerDidImport(_ viewController: RestoreViewController, completion:@escaping (RestoreViewController.ImportResult) -> ())
     func restoreViewControllerDidComplete(_ viewController: RestoreViewController)
 }
 
-@available(iOS 9.0, *)
 class RestoreViewController: BRViewController {
     weak var delegate: RestoreViewControllerDelegate?
     
@@ -141,7 +139,6 @@ class RestoreViewController: BRViewController {
     
 }
 
-@available(iOS 9.0, *)
 extension RestoreViewController {
     enum ImportResult {
         case success

--- a/KinEcosystem/KinEcosystem/Blockchain/Blockchain.swift
+++ b/KinEcosystem/KinEcosystem/Blockchain/Blockchain.swift
@@ -53,7 +53,6 @@ enum TimeoutPolicy {
     case ignore
 }
 
-@available(iOS 9.0, *)
 class Blockchain: NSObject {
 
     var lastKnownWalletAddress: String?
@@ -579,7 +578,6 @@ extension KinAccountsProtocol {
     
 }
 
-@available(iOS 9.0, *)
 extension Blockchain: KinMigrationManagerDelegate {
     public func kinMigrationManagerNeedsVersion(_ kinMigrationManager: KinMigrationManager) -> Promise<KinVersion> {
         guard let query = versionQuery else {
@@ -660,7 +658,6 @@ extension Blockchain: KinMigrationManagerDelegate {
     
 }
 
-@available(iOS 9.0, *)
 extension Blockchain: KinMigrationBIDelegate {
     public func kinMigrationMethodStarted() {
         Kin.track { try MigrationModuleStarted(publicAddress: startingAddress ?? "") }

--- a/KinEcosystem/KinEcosystem/Core/Core.swift
+++ b/KinEcosystem/KinEcosystem/Core/Core.swift
@@ -8,7 +8,6 @@
 
 import KinMigrationModule
 
-@available(iOS 9.0, *)
 class Core {
     
     let network: EcosystemNet

--- a/KinEcosystem/KinEcosystem/Core/Kin.swift
+++ b/KinEcosystem/KinEcosystem/Core/Kin.swift
@@ -58,7 +58,6 @@ public struct NativeOffer: Equatable {
     }
 }
 
-@available(iOS 9.0, *)
 public class Kin {
     
     public static let shared = Kin()

--- a/KinEcosystem/KinEcosystem/Promises/Flows.swift
+++ b/KinEcosystem/KinEcosystem/Promises/Flows.swift
@@ -28,7 +28,6 @@ typealias SOPFlowPromise = Promise<(String, OpenOrder, PaymentMemoIdentifier)>
 typealias POFlowPromise = Promise<(PaymentMemoIdentifier, OpenOrder)>
 typealias Promise = KinUtil.Promise
 
-@available(iOS 9.0, *)
 struct Flows {
         
     static func earn(offerId: String,
@@ -935,7 +934,6 @@ struct Flows {
     
 }
 
-@available(iOS 9.0, *)
 extension Flows {
     static func whitelist() -> WhitelistClosure {
         return { txEnvelope -> (Promise<TransactionEnvelope?>) in

--- a/KinEcosystem/KinEcosystem/View/notNibs/BalanceViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/BalanceViewController.swift
@@ -12,7 +12,6 @@ import KinUtil
 import StellarKit
 import CoreDataStack
 
-@available(iOS 9.0, *)
 class BalanceViewController: KinViewController {
 
     var core: Core!

--- a/KinEcosystem/KinEcosystem/View/notNibs/CouponViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/CouponViewController.swift
@@ -9,9 +9,6 @@
 import UIKit
 import SafariServices
 
-
-
-@available(iOS 9.0, *)
 class CouponViewController: UIViewController, UITextViewDelegate {
 
     struct BIData {

--- a/KinEcosystem/KinEcosystem/View/notNibs/DiamondsLoaderView.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/DiamondsLoaderView.swift
@@ -9,7 +9,6 @@
 import Foundation
 import CoreGraphics
 
-@available(iOS 9.0, *)
 class CircularDashedLoader : CAShapeLayer {
     
     
@@ -121,7 +120,6 @@ class CircularDashedLoader : CAShapeLayer {
     
 }
 
-@available(iOS 9.0, *)
 extension CircularDashedLoader : CAAnimationDelegate {
     func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
         self.removeAllAnimations()
@@ -134,7 +132,6 @@ extension CircularDashedLoader : CAAnimationDelegate {
     }
 }
 
-@available(iOS 9.0, *)
 class DiamondsLoaderView : UIView {
     
     @IBInspectable

--- a/KinEcosystem/KinEcosystem/View/notNibs/EarnOfferViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/EarnOfferViewController.swift
@@ -26,7 +26,6 @@ enum EarnOfferHTMLError: Error {
     case js(Error)
 }
 
-@available(iOS 9.0, *)
 class EarnOfferViewController: KinViewController {
 
     var web: WKWebView!
@@ -119,8 +118,6 @@ class EarnOfferViewController: KinViewController {
     }
 }
 
-
-@available(iOS 9.0, *)
 extension EarnOfferViewController: WKScriptMessageHandler, WKNavigationDelegate, UIScrollViewDelegate, MFMailComposeViewControllerDelegate {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         logVerbose("got messgae: \(message.name)")

--- a/KinEcosystem/KinEcosystem/View/notNibs/InsufficientFundsViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/InsufficientFundsViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 class InsufficientFundsViewController: UIViewController {
 
     @IBOutlet weak var imageView: UIImageView!

--- a/KinEcosystem/KinEcosystem/View/notNibs/KinNavigationViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/KinNavigationViewController.swift
@@ -8,12 +8,10 @@
 
 import UIKit
 
-@available(iOS 9.0, *)
 class KinNavigationChildController : KinViewController {
     weak var kinNavigationController: KinNavigationViewController?
 }
 
-@available(iOS 9.0, *)
 class KinNavigationViewController: KinViewController, UINavigationBarDelegate, UIGestureRecognizerDelegate {
 
     var core: Core!

--- a/KinEcosystem/KinEcosystem/View/notNibs/MarketplaceViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/MarketplaceViewController.swift
@@ -12,7 +12,6 @@ import CoreDataStack
 import StellarKit
 import KinCoreSDK
 
-@available(iOS 9.0, *)
 class MarketplaceViewController: KinNavigationChildController {
     
     weak var core: Core!
@@ -189,7 +188,6 @@ class MarketplaceViewController: KinNavigationChildController {
     }
 }
 
-@available(iOS 9.0, *)
 extension MarketplaceViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         switch collectionView {
@@ -345,7 +343,6 @@ extension MarketplaceViewController: UICollectionViewDelegate, UICollectionViewD
     }
 }
 
-@available(iOS 9.0, *)
 extension MarketplaceViewController: SettingsViewControllerDelegate {
     var didPerformBackup: Bool {
         return core.blockchain.isBackedUp || core.blockchain.lastBalance?.amount == 0

--- a/KinEcosystem/KinEcosystem/View/notNibs/OrdersViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/OrdersViewController.swift
@@ -11,7 +11,6 @@ import CoreData
 import CoreDataStack
 import KinCoreSDK
 
-@available(iOS 9.0, *)
 class OrdersViewController : KinNavigationChildController {
 
     var core: Core!
@@ -101,7 +100,7 @@ class OrdersViewController : KinNavigationChildController {
     }
 
 }
-@available(iOS 9.0, *)
+
 extension OrdersViewController : UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return tableView.tableSection(for: section)?.objectCount ?? 0

--- a/KinEcosystem/KinEcosystem/View/notNibs/SettingsViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/SettingsViewController.swift
@@ -12,7 +12,6 @@ protocol SettingsViewControllerDelegate {
     var didPerformBackup: Bool { get }
 }
 
-@available(iOS 9.0, *)
 class SettingsViewController: UITableViewController {
     private let brManager = BRManager(with: Kin.shared)
     

--- a/KinEcosystem/KinEcosystem/View/notNibs/SpendOfferViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/SpendOfferViewController.swift
@@ -14,7 +14,6 @@ enum SpendOfferError: Error {
     case userCanceled
 }
 
-@available(iOS 9.0, *)
 class SpendOfferViewController: KinViewController {
     
     struct BIData {

--- a/KinEcosystem/KinEcosystem/View/notNibs/WelcomeViewController.swift
+++ b/KinEcosystem/KinEcosystem/View/notNibs/WelcomeViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import KinCoreSDK
 
-@available(iOS 9.0, *)
 class WelcomeViewController: KinViewController {
 
     var core: Core!

--- a/KinEcosystem/KinEcosystem/ViewModel/CouponViewModel.swift
+++ b/KinEcosystem/KinEcosystem/ViewModel/CouponViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import KinUtil
 import KinCoreSDK
-@available(iOS 9.0, *)
+
 class CouponViewModel: Decodable {
     
     var title: NSAttributedString

--- a/KinEcosystem/KinEcosystem/ViewModel/OfferVIewModel.swift
+++ b/KinEcosystem/KinEcosystem/ViewModel/OfferVIewModel.swift
@@ -13,7 +13,6 @@ import Foundation
 import UIKit
 import KinUtil
 
-@available(iOS 9.0, *)
 struct OfferViewModel {
     
     let id: String

--- a/KinEcosystem/KinEcosystem/ViewModel/OrderViewModel.swift
+++ b/KinEcosystem/KinEcosystem/ViewModel/OrderViewModel.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 9.0, *)
 class OrderViewModel {
     
     let id: String

--- a/KinEcosystem/KinEcosystem/ViewModel/SpendViewModel.swift
+++ b/KinEcosystem/KinEcosystem/ViewModel/SpendViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 import KinUtil
 import KinCoreSDK
 
-@available(iOS 9.0, *)
 class SpendViewModel: Decodable {
     
     var title: NSAttributedString

--- a/KinEcosystem/KinEcosystem/extensions/Bundle+extensions.swift
+++ b/KinEcosystem/KinEcosystem/extensions/Bundle+extensions.swift
@@ -12,12 +12,8 @@ import Foundation
 
 extension Bundle {
     class var ecosystem: Bundle {
-        var bundle: Bundle
-        if #available(iOS 9.0, *) {
-            bundle = Bundle(for: Kin.self)
-        } else {
-            bundle = Bundle.main
-        }
+        let bundle = Bundle(for: Kin.self)
+
         if  let bundlePath = bundle.path(forResource: "KinEcosystem", ofType: "bundle"),
             let bundle = Bundle(path: bundlePath) {
             return bundle
@@ -26,12 +22,7 @@ extension Bundle {
     }
     
     class var kinLocalization: Bundle {
-        var bundle: Bundle
-        if #available(iOS 9.0, *) {
-            bundle = Bundle(for: Kin.self)
-        } else {
-            bundle = Bundle.main
-        }
+        let bundle = Bundle(for: Kin.self)
         if  let bundlePath = bundle.path(forResource: "kinLocalization", ofType: "bundle"),
             let bundle = Bundle(path: bundlePath) {
             return bundle

--- a/KinEcosystem/KinEcosystem/extensions/Kin+BackupRestore.swift
+++ b/KinEcosystem/KinEcosystem/extensions/Kin+BackupRestore.swift
@@ -10,7 +10,6 @@ import KinUtil
 
 let passRegex = try! NSRegularExpression(pattern: "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{9,}$", options: [])
 
-@available(iOS 9.0, *)
 extension Kin : KeystoreProvider {
     public func exportAccount(_ password: String) throws -> String {
         guard let core = core else {

--- a/KinEcosystem/KinEcosystem/extensions/NSAttributedString+extensions.swift
+++ b/KinEcosystem/KinEcosystem/extensions/NSAttributedString+extensions.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 9.0, *)
 extension String {
     
     func attributed(_ size: CGFloat, weight: UIFont.Weight, color: UIColor) -> NSAttributedString {

--- a/KinEcosystem/KinEcosystem/extensions/UIImage+extensions.swift
+++ b/KinEcosystem/KinEcosystem/extensions/UIImage+extensions.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 9.0, *)
 extension UIImage {
     class func bundleImage(_ name: String) -> UIImage? {
         return UIImage(named: name, in: Bundle.ecosystem, compatibleWith: nil)

--- a/KinEcosystem/KinEcosystem/extensions/UIView+extensions.swift
+++ b/KinEcosystem/KinEcosystem/extensions/UIView+extensions.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 9.0, *)
 extension UIView {
     func fillSuperview() {
         guard let parent = superview else { return }


### PR DESCRIPTION
Workspace Swift version is now `9.0`. This is the same as the CocoaPods version so developers won't notice a difference, however we now can remove all of the `@available(iOS 9.0, *)` statements.