### PR TITLE
Adjust code for Xcode 11

### DIFF
--- a/KinEcosystem/KinEcosystem/BackupModule/Extension/UIStatusBarStyle+Appearance.swift
+++ b/KinEcosystem/KinEcosystem/BackupModule/Extension/UIStatusBarStyle+Appearance.swift
@@ -15,6 +15,10 @@ extension UIStatusBarStyle {
             return .black
         case .lightContent:
             return .white
+if #available(iOS 13.0, *) {
+        case .darkContent:
+            return .black
+}
         }
     }
 }


### PR DESCRIPTION
#### Main purpose:
Support Xcode 11 + iOS 13
#### Technical description:
AFAK, Apple added dark mode on iOS 13 and there is one more status bar style named `darkContent`.
So in the extension of this repo, the switch code need be updated for that.
I added the `case: .darkContent` and also include the iOS 13 pre-compile marco statement.

